### PR TITLE
Fix issue where OpenShift session times out, but the app session stays alive

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,6 +8,7 @@ class ApplicationController < ActionController::Base
   end
 
   def require_login
+    reset_session if !session[:token_creation_time].nil? and session[:token_creation_time] < 24.hours.ago
     redirect_to '/auth/openshift' if current_user.nil?
   end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -3,6 +3,7 @@ class SessionsController < ApplicationController
     session[:username]    = request.env['omniauth.auth']['info']['nickname']
     session[:uid]         = request.env['omniauth.auth']['uid']
     session[:credentials] = request.env['omniauth.auth']['credentials']
+    session[:token_creation_time] = Time.now
     redirect_to '/'
   end
 


### PR DESCRIPTION
Currently the application session stays alive forever, however, the OpenShift OAuth session is only valid for 24 hours.  If you try and access the page after 24 hours, the application will use an old token and will throw an error.  Currently, the only way to recover is to delete your session cookie.

This PR adds a timestamp to the session, and after 24 hours is clears the session, which requires the user to oAuth to OpenShift again.  